### PR TITLE
SPICD 126: Gameobject relatieve positie (deel 1)

### DIFF
--- a/GameObject.hpp
+++ b/GameObject.hpp
@@ -144,6 +144,22 @@ namespace spic {
             }
 
             /**
+             * Add a child to a parent game object.
+             * This is a safer alternative to the two separate calls to AddChild() and Parent().
+             * @param parent The parent game object.
+             * @param child The child game object.
+             */
+            static void AddChild(std::shared_ptr<GameObject> parent, std::shared_ptr<GameObject> child);
+
+            /**
+             * Adds multiple children to a parent game object.
+             * This is a safer alternative to the two separate calls to AddChild() and Parent().
+             * @param parent The parent game object.
+             * @param child The child game object.
+             */
+            static void AddChildren(std::shared_ptr<GameObject> parent, std::vector<std::shared_ptr<GameObject>> children);
+
+            /**
              * @brief Constructor.
              * @details The new GameObject will also be added to a statically
              *          available collection, the administration.  This makes the

--- a/GameObject.hpp
+++ b/GameObject.hpp
@@ -116,6 +116,32 @@ namespace spic {
             static void Destroy(Component* obj);
 
             /**
+             * Create a new GameObject and add it to the static administration.
+             * @tparam T The type of GameObject
+             * @tparam Args The argument types for the constructor of type T
+             * @param args The arguments for the constructor of type T
+             * @return A shared pointer to a newly created GameObject
+             * @sharedapi
+             */
+            template<typename T, typename...Args, typename std::enable_if<std::is_base_of<GameObject, T>::value>::type* = nullptr>
+            static std::shared_ptr<T> Create(Args&&... args) {
+                // Check if we have a scene
+                auto scene = Engine::Instance().PeekScene();
+                if (!scene) {
+                    Debug::LogWarning("Can not create game object without scene");
+                    return nullptr;
+                }
+
+                // Create a pointer of the game object
+                auto pointer = std::make_shared<T>(std::forward<Args>(args)...);
+
+                // Add it to the scene "static administration"
+                scene->Contents().push_back(pointer);
+
+                return pointer;
+            }
+
+            /**
              * @brief Constructor.
              * @details The new GameObject will also be added to a statically
              *          available collection, the administration.  This makes the
@@ -375,6 +401,13 @@ namespace spic {
              * @sharedapi
              */
             int Layer() const;
+
+            /**
+             * Retrieve the relative position of this gameobject in relation to its parent.
+             * @return the relative position of this gameobject in relation to its parent.
+             * @sharedapi
+             */
+            Point RelativePosition();
 
         private:
             std::string name;

--- a/GameObject.hpp
+++ b/GameObject.hpp
@@ -2,13 +2,14 @@
 #define GAMEOBJECT_H_
 
 #include "Component.hpp"
+#include "Debug.hpp"
+#include "Engine.hpp"
 #include "Transform.hpp"
+#include <iostream>
+#include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
-#include <memory>
-#include "Engine.hpp"
-#include <stdexcept>
-#include "Debug.hpp"
 
 namespace spic {
 
@@ -117,28 +118,29 @@ namespace spic {
 
             /**
              * Create a new GameObject and add it to the static administration.
-             * @tparam T The type of GameObject
-             * @tparam Args The argument types for the constructor of type T
-             * @param args The arguments for the constructor of type T
+             * @tparam GameObjectType The type of GameObject
+             * @tparam GameObjectArgs The argument types for the constructor of type GameObjectType
+             * @param args The arguments for the constructor of type GameObjectType
              * @return A shared pointer to a newly created GameObject
              * @sharedapi
              */
-            template<typename T, typename...Args, typename std::enable_if<std::is_base_of<GameObject, T>::value>::type* = nullptr>
-            static std::shared_ptr<T> Create(Args&&... args) {
-                // Check if we have a scene
-                auto scene = Engine::Instance().PeekScene();
-                if (!scene) {
-                    Debug::LogWarning("Can not create game object without scene");
-                    return nullptr;
-                }
+            template<typename GameObjectType, typename... GameObjectArgs>
+            static std::shared_ptr<GameObjectType> Create(GameObjectArgs&&... args) {
+                return Create_ComponentsFirst<GameObjectType>({}, args...);
+            }
 
-                // Create a pointer of the game object
-                auto pointer = std::make_shared<T>(std::forward<Args>(args)...);
-
-                // Add it to the scene "static administration"
-                scene->Contents().push_back(pointer);
-
-                return pointer;
+            /**
+             * Create a new GameObject with components and add it to the static administration.
+             * @tparam GameObjectType The type of GameObject
+             * @tparam GameObjectArgsAndComponents The argument types for the constructor of type GameObjectType and a
+             * vector of components to add to the game object
+             * @param args The arguments for the constructor of type GameObjectType
+             * @return A shared pointer to a newly created GameObject with the added components
+             * @sharedapi
+             */
+            template<typename GameObjectType, typename... GameObjectArgsAndComponents>
+            static std::shared_ptr<GameObjectType> CreateWithComponents(GameObjectArgsAndComponents&&... input) {
+                return Create_GameObjectArgsWithIndices<GameObjectType>(std::forward_as_tuple(input...), std::make_index_sequence<sizeof...(input) - 1>{});
             }
 
             /**
@@ -425,6 +427,54 @@ namespace spic {
             std::weak_ptr<GameObject> parent;
             std::vector<std::shared_ptr<GameObject>> children;
             std::vector<std::shared_ptr<Component>> components;
+
+            /**
+             * The real function that creates a game object with components in one.
+             * Since you can only add normal parameters before variadic ones we used a little redirection and
+             * meta programming to be able to pass them in a natural order. E.g. GameObject args first, then a vector
+             * of components.
+             * @tparam GameObjectType The type of GameObject
+             * @tparam GameObjectArgs The argument types for the constructor of type GameObjectType
+             * @param comps A vector of components to add to the game object
+             * @param args The arguments for the constructor of type GameObjectType
+             * @return A shared pointer to a newly created GameObject with optional components
+             */
+            template<typename GameObjectType, typename... GameObjectArgs>
+            static std::shared_ptr<GameObjectType> Create_ComponentsFirst(std::vector<std::shared_ptr<Component>> comps, GameObjectArgs... args) {
+                // Check if we have a scene
+                auto scene = Engine::Instance().PeekScene();
+                if (!scene) {
+                    Debug::LogWarning("Can not create game object without scene");
+                    return nullptr;
+                }
+
+                // Create a pointer of the game object
+                std::shared_ptr<GameObjectType> pointer = std::make_shared<GameObjectType>(std::forward<GameObjectArgs>(args)...);
+
+                for (const auto &component : comps) {
+                    component->GameObject(pointer);
+                    pointer->AddComponent(component);
+                }
+
+                // Add it to the scene "static administration"
+                scene->Contents().push_back(pointer);
+
+                return pointer;
+            }
+
+            /**
+             * A redirection trick with metaprogramming to shuffle the order of the arguments when creating a game object.
+             * @tparam GameObjectType The type of GameObject
+             * @tparam GameObjectArgs The argument types for the constructor of type GameObjectType
+             * @param comps A vector of components to add to the game object
+             * @param args The arguments for the constructor of type GameObjectType
+             * @return A shared pointer to a newly created GameObject with optional components
+             */
+            template<typename GameObjectType, typename... GameObjectArgsAndComponents, size_t... GameObjectArgIndices>
+            static std::shared_ptr<GameObjectType> Create_GameObjectArgsWithIndices(std::tuple<GameObjectArgsAndComponents...> args, std::index_sequence<GameObjectArgIndices...>) {
+                auto constexpr ComponentIndex = sizeof...(GameObjectArgsAndComponents) - 1;
+                return Create_ComponentsFirst<GameObjectType>(std::get<ComponentIndex>(args), std::get<GameObjectArgIndices>(args)...);
+            }
     };
 
 }

--- a/Scene.hpp
+++ b/Scene.hpp
@@ -36,7 +36,15 @@ namespace spic {
             std::vector<std::shared_ptr<GameObject>>& Contents();
 
             /**
-             * Called when this scene is first pushed to the stack.
+             * Called when this scene is first created.
+             * Use this method to initialize the objects in this scene.
+             * @sharedapi
+             */
+            virtual void OnCreate();
+
+            /**
+             * Called when this scene is pushed on top of the stack, or when the scene directly above this
+             * one is popped from the stack, thus revealing this one.
              * @sharedapi
              */
             virtual void OnActivate();

--- a/Scene.hpp
+++ b/Scene.hpp
@@ -40,20 +40,20 @@ namespace spic {
              * Use this method to initialize the objects in this scene.
              * @sharedapi
              */
-            virtual void OnCreate();
+            virtual void OnCreate() {};
 
             /**
              * Called when this scene is pushed on top of the stack, or when the scene directly above this
              * one is popped from the stack, thus revealing this one.
              * @sharedapi
              */
-            virtual void OnActivate();
+            virtual void OnActivate() {};
 
             /**
              * Called when this scene is popped from the stack.
              * @sharedapi
              */
-            virtual void OnDeactivate();
+            virtual void OnDeactivate() {};
 
     private:
         std::vector<std::shared_ptr<GameObject>> contents;


### PR DESCRIPTION
## Reviewers

- Jeroen
- Rico

## Gameobjects maken is nu nog cooler

Je kunt de oude manier gebruiken, maar ook direct met components erin zodat je minder snel vergeet beide directies op te zetten

```c++
auto myObjectWithComps = spic::GameObject::CreateWithComponents<DummyGameObject>(
        "Jeff",
        true,
        std::vector<std::shared_ptr<spic::Component>>{
            std::make_shared<spic::Sprite>("assets/penguin.png", false, true, 1, 1),
            std::make_shared<spic::BoxCollider>(200, 200)});
```

Maakt een gameobject aan met een sprite en boxcollider en voegt deze al direct toe aan de scene