### PR TITLE
SPICD 198 added new option for rigidbody

### DIFF
--- a/RigidBody.hpp
+++ b/RigidBody.hpp
@@ -27,9 +27,10 @@ namespace spic {
              * @param mass The mass of the rigid body
              * @param gravityScale The scale of the gravity of the rigid body
              * @param bodyType The type of the rigid body
+             * @param linearDamping The linear damping, can be used to prevent ice-skating
              * @sharedapi
              */
-            RigidBody(double mass, double gravityScale, const BodyType& bodyType);
+            RigidBody(double mass, double gravityScale, const BodyType& bodyType, float linearDamping = 0.0);
 
             /**
              * @brief Apply force to this rigid body.
@@ -83,11 +84,16 @@ namespace spic {
              */
             void GravityScale(double newGravityScale);
 
+            void LinearDamping(float newLinearDamping);
+
+            float LinearDamping() const;
+
         private:
             double mass;
             double gravityScale;
             BodyType bodyType;
             Point force;
+            float linearDamping;
     };
 
 }


### PR DESCRIPTION
De fixed rotation en lineardamping worden nu gezet op de body als ie aangemaakt wordt, anders crasht ie bij lage fps.

Ook is er een nieuwe optie om linear damping te zetten.

Deze values worden goedgezet op banjo in mijn potions branch.